### PR TITLE
Helidon 2.1.0 updates

### DIFF
--- a/helidon-labs-common/pom.xml
+++ b/helidon-labs-common/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.oracle.labs.helidon</groupId>
 	<artifactId>helidon-labs-common</artifactId>
-	<version>2.0.2.0</version>
+	<version>2.1.0.0</version>
 	<packaging>jar</packaging>
 
 	<name>helidon-labs-common</name>
@@ -13,10 +13,10 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<helidon.version>2.0.2</helidon.version>
+		<helidon.version>2.1.0</helidon.version>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-		<version.lombok>1.18.12</version.lombok>
+		<version.lombok>1.18.16</version.lombok>
 	</properties>
 
 	<build>

--- a/helidon-labs-stockmanager/pom.xml
+++ b/helidon-labs-stockmanager/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>io.helidon.applications</groupId>
 		<artifactId>helidon-mp</artifactId>
-		<version>2.0.2</version>
+		<version>2.1.0</version>
 	</parent>
 	<properties>
 		<mainClass>com.oracle.labs.helidon.stockmanager.Main</mainClass>
@@ -24,11 +24,11 @@
 		<ojdbcversion>19.7.0.0</ojdbcversion>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-		<version.lombok>1.18.12</version.lombok>
+		<version.lombok>1.18.16</version.lombok>
 	</properties>
 	<groupId>com.oracle.labs.helidon</groupId>
 	<artifactId>stockmanager</artifactId>
-	<version>2.0.2.0</version>
+	<version>2.1.0.0</version>
 	<name>${project.artifactId}</name>
 
 	<dependencies>
@@ -187,8 +187,10 @@
 			out because Helidon itself brings in slf4j, but if you were using a different 
 			version case then you'd need to specify it yourself, to this is here as a 
 			placeholder / reminder -->
-		<!-- <dependency> <groupId>org.slf4j</groupId> <artifactId>slf4j-jdk14</artifactId> 
-			<version>1.7.26</version> </dependency> -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-jdk14</artifactId>
+		</dependency>
 
 		<!-- Common stuff shared between the stock manager and storefront projects -->
 		<dependency>
@@ -286,7 +288,8 @@
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
 					<artifactId>lifecycle-mapping</artifactId>

--- a/helidon-labs-storefront/pom.xml
+++ b/helidon-labs-storefront/pom.xml
@@ -15,17 +15,17 @@
 	<parent>
 		<groupId>io.helidon.applications</groupId>
 		<artifactId>helidon-mp</artifactId>
-		<version>2.0.2</version>
+		<version>2.1.0</version>
 	</parent>
 	<properties>
 		<mainClass>com.oracle.labs.helidon.storefront.Main</mainClass>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-		<version.lombok>1.18.12</version.lombok>
+		<version.lombok>1.18.16</version.lombok>
 	</properties>
 	<groupId>com.oracle.labs.helidon</groupId>
 	<artifactId>storefront</artifactId>
-	<version>2.0.2.0</version>
+	<version>2.1.0.0</version>
 	<name>${project.artifactId}</name>
 
 	<dependencies>
@@ -65,18 +65,18 @@
 			out because Helidon itself brings in slf4j, but if you were using a different 
 			version case then you'd need to specify it yourself, to this is here as a 
 			placeholder / reminder -->
-		<!-- <dependency> <groupId>org.slf4j</groupId> <artifactId>slf4j-jdk14</artifactId> 
-			<version>1.7.26</version> </dependency> -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-jdk14</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>com.oracle.labs.helidon</groupId>
 			<artifactId>helidon-labs-common</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<!-- tracing calls -->
-		<!-- <dependency>
-			<groupId>io.helidon.tracing</groupId>
-			<artifactId>helidon-tracing-zipkin</artifactId>
-		</dependency>-->
+		<!-- <dependency> <groupId>io.helidon.tracing</groupId> <artifactId>helidon-tracing-zipkin</artifactId> 
+			</dependency> -->
 	</dependencies>
 
 	<build>
@@ -155,7 +155,8 @@
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
 					<artifactId>lifecycle-mapping</artifactId>


### PR DESCRIPTION
Updated for Helidon 2.1.0 now needs the slf4j file as well as updating to lombok 1.18.16